### PR TITLE
feat: comments in manual notes, subscription comments

### DIFF
--- a/dashboard/elements/list-note/list-note.js
+++ b/dashboard/elements/list-note/list-note.js
@@ -30,11 +30,11 @@
 			this.profileUrl = note.profileUrl || false;
 			this.flagged = typeof note.flagged === 'undefined' ? false : note.flagged;
 			this.timestamp = note.timestamp;
+			this.comment = note.comment;
 
 			if (note.type === 'tip' || note.type === 'cheer') {
 				this.amount = note.amount;
 				this.formattedAmount = note.formattedAmount;
-				this.comment = note.comment;
 			} else if (note.type === 'subscription') {
 				this.resub = note.resub;
 				this.months = note.months;

--- a/dashboard/elements/panel-body/panel-body.html
+++ b/dashboard/elements/panel-body/panel-body.html
@@ -26,7 +26,7 @@
 			}
 
 			#flaggedList {
-				height: 240px;
+				height: 180px;
 			}
 
 			#buttons {
@@ -86,6 +86,7 @@
 				<paper-input id="amount" label="Amount" type="number" hidden="[[isSubscription(selectedType)]]" style="flex-shrink: 4;"
 							 min="0"></paper-input>
 			</div>
+			<paper-input id="comment" label="Comment" type="text"></paper-input>
 
 			<paper-button id="send" class="nodecg-info" raised on-tap="send">
 				<span>[[_calcSendButtonText(selectedType)]]</span>

--- a/dashboard/elements/panel-body/panel-body.js
+++ b/dashboard/elements/panel-body/panel-body.js
@@ -80,6 +80,7 @@
 			const type = this.selectedType;
 			const months = this.$.months.value;
 			const amount = this.$.amount.value;
+			const comment = this.$.comment.value;
 
 			const noteOpts = {
 				name,
@@ -87,18 +88,27 @@
 				timestamp: Date.now()
 			};
 
-			if (type === 'subscription') {
-				if (months > 1) {
-					noteOpts.resub = true;
-					noteOpts.months = parseInt(months, 10);
-				} else {
-					noteOpts.resub = false;
-				}
-			} else if (type === 'tip' || type === 'cheer') {
-				noteOpts.amount = parseFloat(amount);
-			} else {
-				console.error('[lfg-nucleus] Invalid manual note type:', type);
-				return;
+			switch (type) {
+				case 'subscription':
+					noteOpts.message = comment;
+					if (months > 1) {
+						noteOpts.resub = true;
+						noteOpts.months = parseInt(months, 10);
+					} else {
+						noteOpts.resub = false;
+					}
+					break;
+				case 'cheer':
+					noteOpts.message = comment;
+					noteOpts.amount = parseFloat(amount);
+					break;
+				case 'tip':
+					noteOpts.comment = comment;
+					noteOpts.amount = parseFloat(amount);
+					break;
+				default:
+					console.error('[lfg-nucleus] Invalid manual note type:', type);
+					return;
 			}
 
 			nodecg.sendMessage('manualNote', noteOpts);

--- a/extension/classes/subscription.js
+++ b/extension/classes/subscription.js
@@ -10,5 +10,6 @@ module.exports = class Subscription extends Note {
 		this.months = options.months || 0;
 		this.resub = Boolean(options.resub);
 		this.profileUrl = `https://twitch.tv/${options.name}`;
+		this.comment = options.message ? options.message.trim() : '';
 	}
 };

--- a/extension/services/lfg-siphon.js
+++ b/extension/services/lfg-siphon.js
@@ -11,7 +11,8 @@ module.exports = function (nodecg, nucleus) {
 			channel: data.channel,
 			resub: data.resub,
 			months: data.months,
-			timestamp: data.ts
+			timestamp: data.ts,
+			message: data.message
 		}));
 	});
 


### PR DESCRIPTION
Adds a comments field to the panel, mainly to help me test graphics that change based on message contents.
Now shows messages from subscriptions, as resubs from lfg-siphon should have this

Screenshot for reference
![](https://puu.sh/vtAce/d3f47183bd.png)