### PR TITLE
fix(dashboard): load webcomponents polyfill

### DIFF
--- a/dashboard/panel.html
+++ b/dashboard/panel.html
@@ -3,6 +3,7 @@
 <head>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge; charset=UTF-8">
 	<meta name="viewport" content="width=device-width" initial-scale="1">
+	<script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
 	<link rel="import" href="elements/panel-body/panel-body.html">
 	<style>
 		body {


### PR DESCRIPTION
Load HTML imports polyfill since it’s no longer supported in Chrome since M80.