### PR TITLE
chore: v4.0.1 and compatible range to NodeCG 1.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lfg-nucleus",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "dependencies": {
     "clone": "^1.0.3",
     "numeral": "^1.5.3",
@@ -16,7 +16,7 @@
     "static": "eslint dashboard/**/*.js extension/**/*.js"
   },
   "nodecg": {
-    "compatibleRange": "~0.9.0",
+    "compatibleRange": "^1.0.0",
     "bundleDependencies": {
       "lfg-filter": "^4.0.0"
     },


### PR DESCRIPTION
NodeCG Range and version bump intended to address production issue.

No real changes to this project, its a dependency of other things and needs the version changed to match. In my personal opinion, it'd be better to merge this project with lfg-nucleus as they're 100% dependent on each other rather than maintain it separately.

The other lfg projects are loose dependencies so they're alright.